### PR TITLE
LangChain tools support with wrapper class

### DIFF
--- a/docs/nodes/agent_node.md
+++ b/docs/nodes/agent_node.md
@@ -38,10 +38,28 @@ research_agent:
 
 - `tools`: A list of tools that the agent can use. Tools are provided to the agent through the `create_react_agent` function from LangGraph.
   The following tools are currently supported:
-  - `tasks.examples.agent_tool_simulation.tools_from_module` All valid tools from a module.
-  - `tasks.examples.agent_tool_simulation.tools_from_class` All valid tools from a class.
+  -  `tasks.examples.agent_tool_simulation.tools_from_module.tool_method` Single tool method with annotation @tool
+  -  `tasks.examples.agent_tool_simulation.tools_from_module` All valid tools from a module.
+  -  `tasks.examples.agent_tool_simulation.tools_from_module.MyToolClass` All valid tools from a class.
   
   Make sure all the necessary tools are decorated with `@tool` from `langchain_core.tools`
+  If you want to use lang chain tools, make sure to import the necessary libraries, implemented get_tools() by inheriting LangChainToolsWrapper base class.
+  Below is the PlayWright wrapper class example which can be used in the tools list in agent_node.
+  ```python
+  from langchain_community.agent_toolkits import PlayWrightBrowserToolkit
+    from langchain_community.tools.playwright.utils import (
+        create_async_playwright_browser,  # A synchronous browser is available, though it isn't compatible with jupyter.\n",	  },
+    )
+    import nest_asyncio
+    
+    class PlayWrightBrowserTools(LangChainToolsWrapper):
+        def get_tools(self):
+            nest_asyncio.apply()
+    
+            async_browser = create_async_playwright_browser()
+            toolkit = PlayWrightBrowserToolkit.from_browser(async_browser=async_browser)
+            return toolkit.get_tools()
+  ```
 
 - `inject_system_messages`: Optional dictionary where keys are conversation turn indices and values are additional system messages to inject at those turns. This allows for dynamic guidance of the agent based on conversation length.
 

--- a/grasp/utils/tool_utils.py
+++ b/grasp/utils/tool_utils.py
@@ -1,5 +1,6 @@
 import importlib
 import sys
+from abc import ABC, abstractmethod
 from inspect import isclass, getmembers
 from typing import List, Callable
 
@@ -8,6 +9,14 @@ from langchain_core.tools import BaseTool
 from grasp.logger.logger_config import logger
 from grasp.utils import utils
 
+class LangChainToolsWrapper(ABC):
+    """
+    Inherit this class and implement get_tools()
+    Which returns tools list to be used directly in the react agent
+    """
+    @abstractmethod
+    def get_tools(self) -> list:
+        pass
 
 def load_tools(tool_paths: List[str]) -> List[Callable]:
     """
@@ -39,6 +48,10 @@ def load_tools(tool_paths: List[str]) -> List[Callable]:
                     # If it's a tool, add it
                     if isinstance(tool_func, BaseTool):
                         tools.append(tool_func)
+                        valid = True
+                        continue
+                    elif issubclass(tool_func, LangChainToolsWrapper):
+                        tools.extend(tool_func().get_tools())
                         valid = True
                         continue
                 except (ImportError, AttributeError):


### PR DESCRIPTION
## Summary
LangChain tools support with wrapper class

## Explain the features implemented:
	- Import the tools and use it in the agent node

## How to Test the feature
Steps for reviewers to verify functionality(example to import PlayWright tool):
1. Add the class (also install relevant libraries)
```python
from langchain_community.agent_toolkits import PlayWrightBrowserToolkit
from langchain_community.tools.playwright.utils import (
    create_async_playwright_browser,  # A synchronous browser is available, though it isn't compatible with jupyter.\n",	  },
)

import nest_asyncio
class PlayWrightBrowserTools(LangChainToolsWrapper):
    def get_tools(self):
        nest_asyncio.apply()

        async_browser = create_async_playwright_browser()
        toolkit = PlayWrightBrowserToolkit.from_browser(async_browser=async_browser)
        return toolkit.get_tools()
```
2. Use the class path in the tools list in the graph config yaml file:
```yaml
tools
    - tasks.examples.agent_tool_simulation.tools_from_class.PlayWrightBrowserTools
```
3. Verify the flow for query like "What are the headers on langchain.com?" 


## Checklist
- [ ] Lint fixes and unit testing done
- [ ] End to end task testing
- [ ] Documentation updated

## Notes
Any caveats, future considerations, or known issues.
