### PR TITLE
Fix grasp utils import

### DIFF
--- a/grasp/__init__.py
+++ b/grasp/__init__.py
@@ -81,7 +81,6 @@ except ImportError:
 # Utility modules
 try:
     from . import utils
-    from .utils import utils
     from .utils import constants
     from .logger.logger_config import (
         logger,


### PR DESCRIPTION
## Summary
utils import was not compatible with python 3.9

## Impacted Features:
Test Failures due to import issue in python 3.9

## How to Test

Run `make test`

## Screenshots (if applicable)
NA

## Checklist
- [x] Lint fixes and unit testing done
- [x] End to end task testing
- [ ] Documentation updated

## Notes
NA
